### PR TITLE
update workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -6,11 +6,11 @@ on:
     branches: [ main ]
 
 jobs:
-  release:
+  Release:
     if: ${{ github.event.pull_request.merged == true }}
     uses: gesslar/Maint/.github/workflows/ReleaseMudlet.yaml@main
+    secrets: inherit
     with:
       quality_check: ""
-    secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two minor adjustments to the `Release` workflow: capitalizes the job name from `release` to `Release`, and reorders `secrets: inherit` to appear before the `with:` block.

- The reusable workflow reference correctly targets `@main` in accordance with the repository's conventions.
- The `secrets: inherit` reorder is functionally equivalent — YAML maps are order-agnostic, so callers receive the same inherited secrets either way.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; both modifications are cosmetic and the reusable workflow call remains functionally identical.

The two changes — job name capitalization and moving `secrets: inherit` above `with:` — do not alter runtime behavior. YAML maps are unordered, so inherited secrets are passed through identically, and GitHub Actions is indifferent to job-name casing. The `@main` pin on the reusable workflow is preserved.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["update workflow"](https://github.com/gesslar/carto/commit/1b206ca6d4c18418fbac82af0eb2e666f4b40be1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38286844)</sub>

<!-- /greptile_comment -->